### PR TITLE
feat: Add github change rules in gemini.md

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -316,4 +316,5 @@
 - github pull request template는 validations의 required는 true, false를 포함해야 함
 
 ### github pull request template 위치
+
 - .github/pull_request_template.md

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -274,3 +274,46 @@
   "endOfLine": "lf"
 }
 ```
+
+## github issue template
+
+### rules
+
+- github issue를 만들 때는 반드시 github issue template를 사용해야 시
+- assignees는 반드시 추가해야 함
+- assignees는 팀원의 github username을 사용해야 함
+- labels는 반드시 추가해야 함
+- github issue template는 .github/ISSUE_TEMPLATE 폴더에 위치해야 함
+- github issue template는 yaml 파일로 작성해야 함
+- github issue template는 name, description, title, labels, body를 포함해야 함
+- github issue template는 body는 배열로 작성해야 함
+- github issue template는 body의 type은 textarea, input, checkbox, dropdown을 사용할 수 있음
+- github issue template는 body의 type이 textarea인 경우 attributes는 label, placeholder, description을 포함해야 함
+- github issue template는 body의 type이 input인 경우 attributes는 label, placeholder를 포함해야 함
+- github issue template는 body의 type이 checkbox인 경우 attributes는 label을 포함해야 함
+- github issue template는 body의 type이 dropdown인 경우 attributes는 label, options를 포함해야 함
+- github issue template는 validations는 required를 포함해야 함
+- github issue template는 validations의 required는 true, false를 포함해야 함
+
+### github issue template 위치
+
+- .github/ISSUE_TEMPLATE/bug_report.yml
+- .github/ISSUE_TEMPLATE/feature_request.yml
+
+## github pull request template
+
+### rules
+
+- github pull request를 만들 때는 반드시 github pull request template를 사용해야 함
+- github pull request template는 .github/pull_request_template.md 파일에 작성해야 함
+- github pull request template는 body는 배열로 작성해야 함
+- github pull request template는 body의 type은 textarea, input, checkbox, dropdown을 사용할 수 있음
+- github pull request template는 body의 type이 textarea인 경우 attributes는 label, placeholder, description을 포함해야 함
+- github pull request template는 body의 type이 input인 경우 attributes는 label, placeholder를 포함해야 함
+- github pull request template는 body의 type이 checkbox인 경우 attributes는 label을 포함해야 함
+- github pull request template는 body의 type이 dropdown인 경우 attributes는 label, options를 포함해야 함
+- github pull request template는 validations는 required를 포함해야 함
+- github pull request template는 validations의 required는 true, false를 포함해야 함
+
+### github pull request template 위치
+- .github/pull_request_template.md


### PR DESCRIPTION
## 변경 내용

.gemini/GEMINI.md에 Gemini가 GitHub 이슈 및 풀 리퀘스트를 생성할 때 따라야 할 규칙을 추가했습니다.

## 변경 이유

Gemini가 일관성 있고 명확한 이슈와 풀 리퀘스트를 생성하도록 하여 프로젝트 관리 효율성을 높이기 위함입니다.

## 확인 항목

- [ ] 테스트를 추가 또는 업데이트했습니다
- [x] 문서를 업데이트했습니다（필요한 경우）
- [x] 관련 이슈를 링크했습니다
- [ ] 코드 검토의 지적 사항에 대응했습니다

## 스크린샷

N/A

## 관련 이슈

#83

## 기타

N/A