### PR TITLE
fix: allow public asset on middleware

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -46,9 +46,6 @@ export async function generateMetadata({
         ja: '/ja',
       },
     },
-    icons: {
-      icon: '/favicon.ico',
-    },
     openGraph: {
       images: '/og-image.png',
     },

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,7 +30,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    '/((?!api|_next|public|favicon\\.ico).*)',
-  ],
+  matcher: ['/((?!api|_next|public|favicon\\.ico).*)'],
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,9 +31,6 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Skip all internal paths (_next)
-    '/((?!_next).*)',
-    // Optional: only run on root (/) URL
-    // '/'
+    '/((?!api|_next|public|favicon\\.ico).*)',
   ],
 }


### PR DESCRIPTION
## 변경 내경

middleware matcher가 public asset을 허용하도록 수정했습니다. 

## 변경 이유

Next.js 13부터 public asset에 대한 미들웨어 처리가 변경되어, public asset에 대한 접근을 허용하도록 수정해야 합니다.

## 확인 항목

- [x] 테스트를 추가 또는 업데이트했습니다
- [ ] 문서를 업데이트했습니다（필요한 경우）
- [x] 관련 이슈를 링크했습니다
- [ ] 코드 검토의 지적 사항에 대응했습니다

## 스크린샷

<!-- UI 의 변경이 있는 경우, before/after 의 스크린샷을 첨부해주세요 -->

## 관련 이슈

<!-- 관련 이슈가 있는 경우, "#이슈 번호" 의 형식으로 기재해주세요 -->
#87

## 기타

<!-- 기타, 검토자에게 전달할 내용이 있으면 기재해주세요 -->
