### PR TITLE
bugfix: avatar image ratio to be 1:2

### DIFF
--- a/components/common/AvartarImage.tsx
+++ b/components/common/AvartarImage.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 
 const projectId = process.env.NEXT_PUBLIC_SUPABASE_PROJECT_ID || ''
 
-export const SupabaseImage = ({
+export const AvatarImage = ({
   src,
   alt,
   width,
@@ -33,7 +33,7 @@ export const SupabaseImage = ({
 
   return (
     <Image
-      className='object-cover rounded-full w-100% h-auto'
+      className='object-cover rounded-full'
       src={src}
       alt={alt}
       width={width}

--- a/components/header/DesktopNav.tsx
+++ b/components/header/DesktopNav.tsx
@@ -1,11 +1,11 @@
 import { User } from '@supabase/supabase-js'
-import { Button } from '../common/Button'
+import { Button } from '@/components/common/Button'
 import { FaGlobe, FaUser } from 'react-icons/fa'
 import { IoMdArrowDropdown } from 'react-icons/io'
 import Link from 'next/link'
 import { Dictionary, Language } from '@/types/dictionaryType'
 import { UserProfile } from '@/types/userType'
-import { SupabaseImage } from '../common/SupabaseImage'
+import { AvatarImage } from '@/components/common/AvartarImage'
 import { CiLogout, CiSettings } from 'react-icons/ci'
 
 export default function DesktopNav({
@@ -45,7 +45,7 @@ export default function DesktopNav({
               aria-haspopup='true'
               aria-expanded={isOpen}>
               {profile?.profilePictureUrl ? (
-                <SupabaseImage
+                <AvatarImage
                   src={`avatars/${profile?.profilePictureUrl}`}
                   alt='Profile Picture'
                   width={48}

--- a/components/settings/ProfileEditForm.tsx
+++ b/components/settings/ProfileEditForm.tsx
@@ -11,7 +11,7 @@ import {
   upsertProfilePicture,
   deleteProfilePicture,
 } from '@/lib/supabaseQueries'
-import { SupabaseImage } from '../common/SupabaseImage'
+import { AvatarImage } from '../common/AvartarImage'
 import { AVATARS_BUCKET_ID } from '@/types/supabaseType'
 import { FaMinus, FaUpload } from 'react-icons/fa'
 import { z } from 'zod'
@@ -181,7 +181,7 @@ export default function ProfileEditForm() {
           />
         </label>
         {previewImage ? (
-          <SupabaseImage
+          <AvatarImage
             src={previewImage}
             alt='Profile Preview'
             width={128}
@@ -193,6 +193,8 @@ export default function ProfileEditForm() {
             alt='Profile Preview'
             width={128}
             height={128}
+            priority={true}
+            className='object-cover rounded-full'
           />
         )}
       </div>


### PR DESCRIPTION
## 변경 내용

아바타 이미지의 비율이 1:2 가 되어버린다. tailwind css의 w-100% 와 h-auto속성간의 충돌이 원인으로 가정 했다. 

## 변경 이유

버그 수정

## 확인 항목

- [ ] 테스트를 추가 또는 업데이트했습니다
- [ ] 문서를 업데이트했습니다（필요한 경우）
- [ ] 관련 이슈를 링크했습니다
- [ ] 코드 검토의 지적 사항에 대응했습니다

## 스크린샷

<!-- UI 의 변경이 있는 경우, before/after 의 스크린샷을 첨부해주세요 -->

## 관련 이슈

<!-- 관련 이슈가 있는 경우, "#이슈 번호" 의 형식으로 기재해주세요 -->

## 기타

<!-- 기타, 검토자에게 전달할 내용이 있으면 기재해주세요 -->
