### PR TITLE
feature: display root page with user setting locale

### DIFF
--- a/app/[lang]/settings/page.tsx
+++ b/app/[lang]/settings/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { useUser } from '@/hooks/useUser'
 import { useTheme } from '@/hooks/useTheme'
 import { FaArrowUpRightFromSquare } from 'react-icons/fa6'
+import { setCookie } from '@/lib/cookie'
 
 export default function SettingsPage() {
   const { dict, lang } = useDictionary()
@@ -14,6 +15,8 @@ export default function SettingsPage() {
   const { theme, setTheme } = useTheme()
 
   const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    // set cookie
+    setCookie('NEXT_LOCALE', e.target.value, 365)
     redirect(`/${e.target.value}/settings`)
   }
 

--- a/components/header/DesktopNav.tsx
+++ b/components/header/DesktopNav.tsx
@@ -7,6 +7,7 @@ import { Dictionary, Language } from '@/types/dictionaryType'
 import { UserProfile } from '@/types/userType'
 import { AvatarImage } from '@/components/common/AvartarImage'
 import { CiLogout, CiSettings } from 'react-icons/ci'
+import { setCookie } from '@/lib/cookie'
 
 export default function DesktopNav({
   user,
@@ -132,7 +133,10 @@ export default function DesktopNav({
                     key={language.code}
                     href={redirectedPathName(language.code)}
                     className='flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700'
-                    onClick={() => setIsOpen(false)}>
+                    onClick={() => {
+                      setIsOpen(false)
+                      setCookie('NEXT_LOCALE', language.code, 365)
+                    }}>
                     <span className='mr-2'>{language.flag}</span>
                     {language.name}
                   </Link>

--- a/components/header/MobileNav.tsx
+++ b/components/header/MobileNav.tsx
@@ -6,6 +6,7 @@ import { Dictionary, Language } from '@/types/dictionaryType'
 import { IoMdArrowDropdown } from 'react-icons/io'
 import { useRef, useState } from 'react'
 import { UserProfile } from '@/types/userType'
+import { setCookie } from '@/lib/cookie'
 
 export default function MobileNav({
   user,
@@ -114,6 +115,7 @@ export default function MobileNav({
                           onClick={() => {
                             setIsLanguageOpen(false)
                             setIsMobileMenuOpen(false)
+                            setCookie('NEXT_LOCALE', language.code, 365)
                           }}>
                           <span>{language.flag}</span>
                           <Button

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -1,0 +1,6 @@
+export const setCookie = (name: string, value: string, days: number) => {
+  const date = new Date()
+  date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
+  const expires = 'expires=' + date.toUTCString()
+  document.cookie = name + '=' + value + '; ' + expires + '; path=/'
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,9 @@
+'use server'
+
 import { NextRequest, NextResponse } from 'next/server'
 import Negotiator from 'negotiator'
 import { match } from '@formatjs/intl-localematcher'
+import { cookies } from 'next/dist/server/request/cookies'
 
 let locales = ['ko', 'en', 'ja']
 
@@ -12,7 +15,7 @@ function getLocale(request: NextRequest): string {
   return match(languages, locales, 'en')
 }
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   // Check if there is any supported locale in the pathname
   const { pathname } = request.nextUrl
   const pathnameHasLocale = locales.some(
@@ -21,8 +24,9 @@ export function middleware(request: NextRequest) {
 
   if (pathnameHasLocale) return
 
+  const cookieStore = await cookies()
+  const locale = cookieStore.get('NEXT_LOCALE')?.value || getLocale(request)
   // Redirect if there is no locale
-  const locale = getLocale(request)
   request.nextUrl.pathname = `/${locale}${pathname}`
   // e.g. incoming request is /products
   // The new URL is now /en/products


### PR DESCRIPTION
## 변경 내경

display root page with user setting locale

## 변경 이유

유저가 자기가 설정한 언어가 탭을 닫으면 초기화 된다. 

## 확인 항목

- [ ] 테스트를 추가 또는 업데이트했습니다
- [ ] 문서를 업데이트했습니다（필요한 경우）
- [ ] 관련 이슈를 링크했습니다
- [ ] 코드 검토의 지적 사항에 대응했습니다

## 스크린샷

<!-- UI 의 변경이 있는 경우, before/after 의 스크린샷을 첨부해주세요 -->

## 관련 이슈

#91 

## 기타

<!-- 기타, 검토자에게 전달할 내용이 있으면 기재해주세요 -->
